### PR TITLE
License Change

### DIFF
--- a/LICENSE.md
+++ b/LICENSE.md
@@ -31,4 +31,4 @@ All other content, including code snippets posted in public forums, is licensed 
 
 Attribution of contributions to the FarmData2 repository are maintained in the logs of the git version control system.  The [AUTHORS.md](AUTHORS.md) file contains a list of all contributors to the repository and is updated periodically.
 
-Attribution of content in public forums is typically maintained by the appropriate forum (e.g. threads, usernames, cross linked issues, etc). If not however, it is the contributor's responsibility to ensure that proper attribution is made based.
+Attribution of content in public forums is typically maintained by the appropriate forum (e.g. threads, usernames, cross linked issues, etc). If not however, it is the contributor's responsibility to ensure that proper attribution is made.

--- a/username
+++ b/username
@@ -1,0 +1,13 @@
+safe.directory=*
+safe.directory=
+push.default=simple
+alias.lg=log --color --graph --pretty=format:'%Cred%h%Creset -%C(yellow)%d%Creset %s %Cgreen(%cr) %C(bold blue)<%an>%Creset' --abbrev-commit
+credential.helper=/usr/bin/gp credential-helper
+user.name=elliotbenoit
+user.email=thelemon8787@gmail.com
+pull.ff=only
+init.defaultbranch=main
+merge.conflictstyle=diff3
+merge.tool=vscode
+mergetool.keepbackup=false
+mergetool.vscode.cmd=code --wait $MERGED


### PR DESCRIPTION
__Pull Request Description__

Fixes issue #27 Remove extra word  

---
__Licensing Certification__

FarmData2 is a [Free Cultural Work](https://freedomdefined.org/Definition) and all accepted contributions are licensed as described in the LICENSE.md file. This requires that the contributor holds the rights to do so. By submitting this pull request __I certify that I satisfy the terms of the [Developer Certificate of Origin](https://developercertificate.org/)__ for its contents.
