### PR TITLE
Made the GNOME Community Engagement Challenge a link

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,7 +31,7 @@ FarmData2 is powered by the farmOS open source project.
 Support and assistance with FarmData2 development has been received from [The Non-Profit FOSS Institute](https://npfi.org/).
 
 The development of FarmData2 has received partial support from:
-* The GNOME Community Engagement Challenge:
+* [The GNOME Community Engagement Challenge](https://www.gnome.org/challenge/):
   * [![Phase 1 Badge](media/GNOME-CEC-p1-small.png)](media/GNOME-CEC-p1.png)[![Phase 2 Badge](media/GNOME-CEC-p2-small.png)](media/GNOME-CEC-p2.png)    
 * The National Science Foundation (DUE-2013069) - Collaborative Research: Broadening Participation in Computing through Authentic, Collaborative Engagement with Computing for the Greater Good.
 * [Zulip](https://zulip.com) provides sponsored hosting for [FarmData2 community discussions](https://farmdata2.zulipchat.com/#narrow/stream/270883-general).


### PR DESCRIPTION
__Pull Request Description__

I Made the phrase "GNOME Community Engagement Challenge" into a link in the Acknowledgements at the bottom of the README.md file, using the link https://www.gnome.org/challenge/. Fixes issue #38 .

---
__Licensing Certification__

FarmData2 is a [Free Cultural Work](https://freedomdefined.org/Definition) and all accepted contributions are licensed as described in the LICENSE.md file. This requires that the contributor holds the rights to do so. By submitting this pull request __I certify that I satisfy the terms of the [Developer Certificate of Origin](https://developercertificate.org/)__ for its contents.
